### PR TITLE
Update ref path in ENTRYPOINT

### DIFF
--- a/.github/workflows/v1beta.yml
+++ b/.github/workflows/v1beta.yml
@@ -1,7 +1,7 @@
 name: oci-spec-ci
 on:
-  #push:
-    #branches: [ v1beta_oci_spec ]
+  push:
+    branches: [ v1beta_oci_spec ]
   pull_request:
     branches: [ v1beta_oci_spec ]
     types: [opened, synchronize]
@@ -46,7 +46,7 @@ jobs:
           ./scripts/docker-deployment-sim.sh
         
       - name: Container Images Deployment
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: github.event_name == 'push'
         env:
           DOCKER_USERNAME: apoloyasudadocker
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}

--- a/.github/workflows/v1beta.yml
+++ b/.github/workflows/v1beta.yml
@@ -46,7 +46,7 @@ jobs:
           ./scripts/docker-deployment-sim.sh
         
       - name: Container Images Deployment
-        #if: github.event.pull_request.merged == true
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         env:
           DOCKER_USERNAME: apoloyasudadocker
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}

--- a/.github/workflows/v1beta.yml
+++ b/.github/workflows/v1beta.yml
@@ -4,7 +4,7 @@ on:
     #branches: [ v1beta_oci_spec ]
   pull_request:
     branches: [ v1beta_oci_spec ]
-    types: [closed, opened, synchronize]
+    types: [opened, synchronize]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    environment: v1
     env:
       DOCKER_HUB_AGENT_TAG: "enterpriseconnect/agent:v1beta"
       DOCKER_HUB_PLUGIN_TAG: "enterpriseconnect/plugins:v1beta"

--- a/.github/workflows/v1beta.yml
+++ b/.github/workflows/v1beta.yml
@@ -1,9 +1,10 @@
 name: oci-spec-ci
 on:
-  push:
-    branches: [ v1beta_oci_spec ]
+  #push:
+    #branches: [ v1beta_oci_spec ]
   pull_request:
     branches: [ v1beta_oci_spec ]
+    types: [closed, opened, synchronize]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/spec/agent/Dockerfile
+++ b/spec/agent/Dockerfile
@@ -32,4 +32,4 @@ RUN ["/bin/bash", "-c", "wget -q --show-progress -O ~/v1beta.linux64.sh https://
 
 RUN chmod +x ~/v1beta.linux64.sh
 
-ENTRYPOINT ["~/v1beta.linux64.sh"]
+ENTRYPOINT ["./v1beta.linux64.sh"]


### PR DESCRIPTION
This is to fix [item](https://github.com/EC-Release/oci2/issues/2)

Agent image unable to identify the file v1beta.linux64.sh and hence throwing the error. Issue fixed by giving the right ref path to the file.