### PR TITLE
fix ci job for the updated tengu api spec.

### DIFF
--- a/.github/workflows/v1.2beta_api.yml
+++ b/.github/workflows/v1.2beta_api.yml
@@ -1,11 +1,13 @@
 name: v1.2beta_api_ci
 on:
   # Triggers the workflow on push or pull request events but only for the v1.1beta_helm_pkg_update_lber_ay branch
-  push:
-    branches: [ v1.2beta_api ]
+  #push:
+  #  branches: [ v1.2beta_api ]
+  
   pull_request:
     branches: [ v1.2beta_api ]
-
+    types: [closed, opened, synchronize]
+    
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -51,3 +53,4 @@ jobs:
           echo $REGISTRY_TKN_GITHUB | docker login $GITHUB_REGISTRY -u $GITHUB_USR --password-stdin
           docker push $GITHUB_API_TAG
     
+


### PR DESCRIPTION
Re-create the PR for the latest build which did not trigger properly due to the untagged PR merge event.