### PR TITLE
correct ci event for merging practice

### DIFF
--- a/.github/workflows/v1.2beta_api.yml
+++ b/.github/workflows/v1.2beta_api.yml
@@ -5,7 +5,7 @@ on:
   
   pull_request:
     branches: [ v1.2beta_api ]
-    types: [closed, opened, synchronize]
+    types: [opened, synchronize]
     
   workflow_dispatch:
 


### PR DESCRIPTION
remove the "closed" event on pr. Leave "push" event for final step.